### PR TITLE
fix: regex should treat newline like a regular char

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const ANSI_SEQUENCE = /^(.*?)(\x1b\[[^m]+m|\x1b\]8;;.*?(\x1b\\|\u0007))/;
+const ANSI_SEQUENCE = /^([\s\S]*?)(\x1b\[[^m]+m|\x1b\]8;;[\s\S]*?(\x1b\\|\u0007))/;
 
 let splitGraphemes;
 


### PR DESCRIPTION
`/./` is not the correct any-char regex
`/[\s\S]/` is

This lib broke on newlines

Mirror of: https://github.com/arcanis/slice-ansi/pull/13
See: https://github.com/pnpm/pnpm/issues/9642

An alternative is to add `/s` flag (but that is more intrusive and `engines` are not set)
Ref: https://github.com/tc39/proposal-regexp-dotall-flag